### PR TITLE
Delete LOAD_MODULE_IN_ELECTRON env var 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,28 @@
             "ms": "2.0.0"
           }
         },
+        "fs-extra": {
+          "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
+          "requires": {
+            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
+              "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+        },
         "rise-common-electron": {
           "version": "git://github.com/Rise-Vision/rise-common-electron.git#467d4c639ee1826961b5f7717f463ce9bd324b23",
           "requires": {
@@ -467,6 +489,9 @@
               }
             }
           }
+        },
+        "windows-shortcuts": {
+          "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b"
         }
       }
     },
@@ -1366,28 +1391,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "fs-extra": {
-      "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
-      "requires": {
-        "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-        },
-        "rimraf": {
-          "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
-          "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-          }
-        }
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4224,9 +4227,6 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
-    },
-    "windows-shortcuts": {
-      "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b"
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/src/main/watchdog/index.js
+++ b/src/main/watchdog/index.js
@@ -1,4 +1,5 @@
 delete process.env.ELECTRON_RUN_AS_NODE;
+delete process.env.LOAD_MODULE_IN_ELECTRON;
 
 const path = require("path");
 const moduleCommon = require("common-display-module");


### PR DESCRIPTION
- Delete LOAD_MODULE_IN_ELECTRON env var so Installer runs properly upon a restart. Otherwise, Launcher runs as if it is Player and no further execution happens in Launcher, thus preventing all other modules from starting. 