### PR TITLE
prevent debug data go to file

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -20,8 +20,6 @@ global.log = require("rise-common-electron").logger(preventBQLog ? null : extern
 
 log.resetLogFiles(Math.pow(10,5));
 
-log.debug = log.file;
-
 if(preventBQLog) { log.file("Environment variable RISE_PREVENT_BQ_LOG. Not logging to BQ."); }
 
 displaySettings = commonConfig.getDisplaySettingsSync();


### PR DESCRIPTION
This is still polluting log files in media players with all messages including heartbeats. When log is trimmed we lose what could be valuable information from previous days.
