### PR TITLE
Remove applying ppapi-flash-path

### DIFF
--- a/src/main/player/main-controller.js
+++ b/src/main/player/main-controller.js
@@ -4,8 +4,6 @@ launcher = require("../player/launcher.js"),
 config = require("./config.js"),
 commonConfig = require("common-display-module"),
 onlineDetection = require("../player/online-detection.js"),
-flashPluginFileName = platform.isWindows() ? "pepflashplayer.dll" : "libpepflashplayer.so",
-flashPluginPath = require("path").join(commonConfig.getInstallDir(), flashPluginFileName),
 path = require("path");
 
 let app,
@@ -72,8 +70,6 @@ module.exports = {
     globalShortcut = imports.globalShortcut;
     BrowserWindow = imports.BrowserWindow;
     protocol = imports.protocol;
-
-    app.commandLine.appendSwitch("ppapi-flash-path", flashPluginPath);
 
     protocol.registerStandardSchemes(["rchttp", "rchttps"], {secure: true});
 


### PR DESCRIPTION
- We haven't been providing the pepper flash plugins in *rvplayer* directory where Installer has been looking for them to provide the path to a Electron browser window. This impacts the browser to have an invalid flash plugin path. This has impacted a live stream where it is setting its VideoJS instance preference to Flash first and HTML5 second. The video player results in displaying "Couldn't load plug-in"
- We don't support Flash so there is no reason to be setting the "ppapi-flash-path". Removing it which fixes the live stream as it falls back to HTML5 video player. 