### PR TITLE
Ensure CCI docker image is latest for use of jq in stable build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   "test_unit":
     docker: &DOCKERIMAGE
-      - image: jenkinsrise/cci-v2-launcher-electron:0.0.5
+      - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
`jq` is required for stable build in order to create newline delimited json