### PR TITLE
Feature/log uncaught exceptions into bq

### DIFF
--- a/src/main/player/launcher.js
+++ b/src/main/player/launcher.js
@@ -1,22 +1,23 @@
 const config = require("./config");
-const messaging = require("./messaging.js");
-const screenshot = require("./screenshot.js");
-const dupeId = require("./duplicate-id.js");
-const restart = require("./restart.js");
-const reboot = require("./reboot.js");
-const scheduledReboot= require("./scheduled-reboot.js");
+const messaging = require("./messaging");
+const screenshot = require("./screenshot");
+const dupeId = require("./duplicate-id");
+const restart = require("./restart");
+const reboot = require("./reboot");
+const scheduledReboot= require("./scheduled-reboot");
 const platform = require("rise-common-electron").platform;
-const installer = require("./installer.js");
-const watchdog = require("./watchdog.js");
-const riseCacheWatchdog = require("../player/rise-cache-watchdog.js");
-const gcsPolling = require("./gcs-polling.js");
-const gcs = require("./gcs.js");
-const viewerWindowBindings = require("../viewer/window-bindings.js");
+const installer = require("./installer");
+const watchdog = require("./watchdog");
+const riseCacheWatchdog = require("../player/rise-cache-watchdog");
+const gcsPolling = require("./gcs-polling");
+const gcs = require("./gcs");
+const viewerWindowBindings = require("../viewer/window-bindings");
 const viewer = require("../viewer");
-const onlineDetection = require("./online-detection.js");
-const offlineSubscriptionCheck = require("./offline-subscription-check.js");
-const viewerContentLoader = require("../viewer/content-loader.js");
+const onlineDetection = require("./online-detection");
+const offlineSubscriptionCheck = require("./offline-subscription-check");
+const viewerContentLoader = require("../viewer/content-loader");
 const heartbeat = require("common-display-module/heartbeat");
+const uncaughtExceptions = require("./uncaught-exceptions");
 
 module.exports = {
   launch() {
@@ -98,6 +99,7 @@ module.exports = {
       installer.playerLoadComplete();
     })
     .then(gcsPolling.init)
-    .then(() => heartbeat.startHeartbeatInterval(config.moduleName));
+    .then(() => heartbeat.startHeartbeatInterval(config.moduleName))
+    .then(uncaughtExceptions.sendToBQ);
   }
 };

--- a/src/main/player/uncaught-exceptions.js
+++ b/src/main/player/uncaught-exceptions.js
@@ -1,0 +1,28 @@
+const config = require("./config");
+const fs = require("fs-extra");
+const platform = require("rise-common-electron").platform;
+
+function sendToBQ() {
+  return Promise.resolve()
+  .then(() => {
+    const path = config.getUncaughtErrorFileName();
+
+    if (platform.fileExists(path)) {
+      return platform.readTextFile(path)
+      .then(content => {
+        log.error('uncaught exception file found', `Uncaught exception: ${content}`);
+
+        return new Promise(resolve => {
+          fs.remove(path, error => {
+            error && log.error(`could not delete ${path}`, error);
+
+            resolve();
+          });
+        });
+      });
+    }
+  })
+  .catch(error => log.error('error while retrieving previous uncaught exceptions', error.stack));
+}
+
+module.exports = {sendToBQ};

--- a/src/main/player/uncaught-exceptions.js
+++ b/src/main/player/uncaught-exceptions.js
@@ -3,26 +3,25 @@ const fs = require("fs-extra");
 const platform = require("rise-common-electron").platform;
 
 function sendToBQ() {
-  return Promise.resolve()
-  .then(() => {
-    const path = config.getUncaughtErrorFileName();
+  const path = config.getUncaughtErrorFileName();
 
-    if (platform.fileExists(path)) {
-      return platform.readTextFile(path)
-      .then(content => {
-        log.error('uncaught exception file found', `Uncaught exception: ${content}`);
+  if (platform.fileExists(path)) {
+    return platform.readTextFile(path)
+    .then(content => {
+      log.error('uncaught exception file found', `Uncaught exception: ${content}`);
 
-        return new Promise(resolve => {
-          fs.remove(path, error => {
-            error && log.error(`could not delete ${path}`, error);
+      return new Promise(resolve => {
+        fs.remove(path, error => {
+          error && log.error(`could not delete ${path}`, error);
 
-            resolve();
-          });
+          resolve();
         });
       });
-    }
-  })
-  .catch(error => log.error('error while retrieving previous uncaught exceptions', error.stack));
+    })
+    .catch(error => log.error('error while retrieving previous uncaught exceptions', error.stack));
+  }
+
+  return Promise.resolve();
 }
 
 module.exports = {sendToBQ};

--- a/src/main/player/uncaught-exceptions.js
+++ b/src/main/player/uncaught-exceptions.js
@@ -1,5 +1,4 @@
 const config = require("./config");
-const fs = require("fs-extra");
 const platform = require("rise-common-electron").platform;
 
 function sendToBQ() {
@@ -10,13 +9,8 @@ function sendToBQ() {
     .then(content => {
       log.error('uncaught exception file found', `Uncaught exception: ${content}`);
 
-      return new Promise(resolve => {
-        fs.remove(path, error => {
-          error && log.error(`could not delete ${path}`, error);
-
-          resolve();
-        });
-      });
+      return platform.renameFile(path, `${path}.bak`)
+      .catch(error => log.error(error.message || `could not rename ${path} to ${path}.bak`, error.error ? error.error.stack : error.stack));
     })
     .catch(error => log.error('error while retrieving previous uncaught exceptions', error.stack));
   }

--- a/src/test/integration/uncaught-exceptions.js
+++ b/src/test/integration/uncaught-exceptions.js
@@ -1,0 +1,52 @@
+const assert = require("assert");
+const fs = require("fs-extra");
+const platform = require("rise-common-electron").platform;
+const simple = require("simple-mock");
+
+const config = require("../../main/player/config");
+const uncaughtExceptions = require("../../main/player/uncaught-exceptions");
+
+describe("Uncaught Exceptions - Integration", () => {
+
+  const cachedLog = global.log;
+  const path = config.getUncaughtErrorFileName();
+
+  beforeEach(done => {
+    global.log = {
+      all() {},
+      file() {},
+      external() {},
+      error: simple.stub(),
+      debug: console.log
+    };
+
+    fs.remove(path, () => done());
+  });
+
+  afterEach(() => simple.restore());
+  after(() => global.log = cachedLog);
+
+  it("should send error if an uncaught exception file exists", () => {
+    return platform.writeTextFile(path, 'test error content')
+    .then(() => {
+      assert(platform.fileExists(path));
+
+      return uncaughtExceptions.sendToBQ();
+    })
+    .then(() => {
+      assert.equal(global.log.error.callCount, 1);
+      assert.equal(global.log.error.lastCall.args[0], 'uncaught exception file found');
+      assert.equal(global.log.error.lastCall.args[1], 'Uncaught exception: test error content');
+
+      assert(!platform.fileExists(path));
+    });
+  });
+
+  it("should not send error if no uncaught exception file exists", () => {
+    assert(!platform.fileExists(path));
+
+    return uncaughtExceptions.sendToBQ()
+    .then(() => assert(!global.log.error.called));
+  });
+
+});

--- a/src/test/integration/uncaught-exceptions.js
+++ b/src/test/integration/uncaught-exceptions.js
@@ -10,6 +10,7 @@ describe("Uncaught Exceptions - Integration", () => {
 
   const cachedLog = global.log;
   const path = config.getUncaughtErrorFileName();
+  const backupPath = `${path}.bak`;
 
   beforeEach(done => {
     global.log = {
@@ -26,8 +27,42 @@ describe("Uncaught Exceptions - Integration", () => {
   afterEach(() => simple.restore());
   after(() => global.log = cachedLog);
 
-  it("should send error if an uncaught exception file exists", () => {
+  it("should send error if an uncaught exception file exists", done => {
+    fs.remove(backupPath, () => {
+      platform.writeTextFile(path, 'test error content')
+      .then(() => {
+        assert(platform.fileExists(path));
+
+        return uncaughtExceptions.sendToBQ();
+      })
+      .then(() => {
+        assert.equal(global.log.error.callCount, 1);
+        assert.equal(global.log.error.lastCall.args[0], 'uncaught exception file found');
+        assert.equal(global.log.error.lastCall.args[1], 'Uncaught exception: test error content');
+
+        assert(!platform.fileExists(path));
+        assert(platform.fileExists(backupPath));
+
+        return platform.readTextFile(backupPath);
+      })
+      .then(content => {
+        assert.equal(content, 'test error content');
+
+        done();
+      });
+    });
+  });
+
+  it("should not send error if no uncaught exception file exists", () => {
+    assert(!platform.fileExists(path));
+
+    return uncaughtExceptions.sendToBQ()
+    .then(() => assert(!global.log.error.called));
+  });
+
+  it("should move uncaught exception file to backup even if a backup file already exists", () => {
     return platform.writeTextFile(path, 'test error content')
+    .then(() => platform.writeTextFile(backupPath, 'old backup content'))
     .then(() => {
       assert(platform.fileExists(path));
 
@@ -39,14 +74,11 @@ describe("Uncaught Exceptions - Integration", () => {
       assert.equal(global.log.error.lastCall.args[1], 'Uncaught exception: test error content');
 
       assert(!platform.fileExists(path));
-    });
-  });
+      assert(platform.fileExists(backupPath));
 
-  it("should not send error if no uncaught exception file exists", () => {
-    assert(!platform.fileExists(path));
-
-    return uncaughtExceptions.sendToBQ()
-    .then(() => assert(!global.log.error.called));
+      return platform.readTextFile(backupPath);
+    })
+    .then(content => assert.equal(content, 'test error content'));
   });
 
 });


### PR DESCRIPTION
Sends the uncaught-exception.json file as an error to BQ so we can better understand if something is causing a launcher ( or player ) crash, and may give us more insight into some install / upgrade failures.