### PR TITLE
correct parameter order in log.error calls

### DIFF
--- a/src/main/player/rise-cache-watchdog.js
+++ b/src/main/player/rise-cache-watchdog.js
@@ -46,7 +46,7 @@ function startCache() {
   }
   catch (err) {
     cache = null;
-    log.error("starting rise cache v2", inspect(err));
+    log.error(`starting rise cache v2: ${ inspect(err) }`, "starting rise cache v2");
   }
 }
 

--- a/src/main/player/screenshot.js
+++ b/src/main/player/screenshot.js
@@ -32,7 +32,7 @@ module.exports = {
         log.file(`screenshot uploaded - 'screenshot-saved' message sent to ${displayId}/${data.clientId}`);
       })
       .catch((err)=>{
-        log.error("uploading screenshot", err);
+        log.error(err, "uploading screenshot");
         messaging.write({
           msg: "screenshot-failed",
           clientId: data.clientId
@@ -57,7 +57,7 @@ module.exports = {
     .then(filePath => commonMessaging.broadcastMessage({
       from: config.moduleName, topic: 'local-screenshot-result', filePath
     }))
-    .catch(error => log.error('error while handling local screenshot request', error.stack));
+    .catch(error => log.error(error.stack, 'error while handling local screenshot request'));
   }
 };
 

--- a/src/main/player/uncaught-exceptions.js
+++ b/src/main/player/uncaught-exceptions.js
@@ -7,12 +7,12 @@ function sendToBQ() {
   if (platform.fileExists(path)) {
     return platform.readTextFile(path)
     .then(content => {
-      log.error('uncaught exception file found', `Uncaught exception: ${content}`);
+      log.error(`Uncaught exception: ${content}`, 'uncaught exception file found');
 
       return platform.renameFile(path, `${path}.bak`)
-      .catch(error => log.error(error.message || `could not rename ${path} to ${path}.bak`, error.error ? error.error.stack : error.stack));
+      .catch(error => log.error(error.error ? error.error.stack : error.stack, error.message || `could not rename ${path} to ${path}.bak`));
     })
-    .catch(error => log.error('error while retrieving previous uncaught exceptions', error.stack));
+    .catch(error => log.error(error.stack, 'error while retrieving previous uncaught exceptions'));
   }
 
   return Promise.resolve();

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -55,8 +55,8 @@ function registerEvents(window) {
 
       platform.runFunction(configLogger.logClientInfo.bind(null, data), RETRIES, RETRY_TIMEOUT, RETRY_DELAY)
         .catch((err)=>{
-          log.error("logging client info", err);
-          log.file(require("util").inspect(err, { depth: null }));
+          const errorDetail = require("util").inspect(err, { depth: null });
+          log.error(errorDetail, "logging client info");
         });
     } else if(data.message === "data-handler-registered") {
       if (dataHandlerRegistered && typeof dataHandlerRegistered === "function") {

--- a/src/test/integration/uncaught-exceptions.js
+++ b/src/test/integration/uncaught-exceptions.js
@@ -37,8 +37,8 @@ describe("Uncaught Exceptions - Integration", () => {
       })
       .then(() => {
         assert.equal(global.log.error.callCount, 1);
-        assert.equal(global.log.error.lastCall.args[0], 'uncaught exception file found');
-        assert.equal(global.log.error.lastCall.args[1], 'Uncaught exception: test error content');
+        assert.equal(global.log.error.lastCall.args[0], 'Uncaught exception: test error content');
+        assert.equal(global.log.error.lastCall.args[1], 'uncaught exception file found');
 
         assert(!platform.fileExists(path));
         assert(platform.fileExists(backupPath));
@@ -70,8 +70,8 @@ describe("Uncaught Exceptions - Integration", () => {
     })
     .then(() => {
       assert.equal(global.log.error.callCount, 1);
-      assert.equal(global.log.error.lastCall.args[0], 'uncaught exception file found');
-      assert.equal(global.log.error.lastCall.args[1], 'Uncaught exception: test error content');
+      assert.equal(global.log.error.lastCall.args[0], 'Uncaught exception: test error content');
+      assert.equal(global.log.error.lastCall.args[1], 'uncaught exception file found');
 
       assert(!platform.fileExists(path));
       assert(platform.fileExists(backupPath));

--- a/src/test/unit/screenshot.js
+++ b/src/test/unit/screenshot.js
@@ -74,7 +74,7 @@ describe("Screenshot", function() {
 
     return messagingScreenshotRequestPromise
     .then(()=>{
-      assert.equal(log.error.lastCall.args[1], "simulated failure message from viewer");
+      assert.equal(log.error.lastCall.args[0], "simulated failure message from viewer");
     });
   });
 });


### PR DESCRIPTION
Good news is that we received uncaught exceptions in BQ
Bad news is that the detail goes first and the user friendly message goes second in log.error():
https://github.com/Rise-Vision/rise-common-electron/blob/master/logger.js#L87

so we aren't getting the relevant detail into BQ. This fixes that.
