### PR TITLE
Handle default content json file with no schedule

### DIFF
--- a/src/main/player/content-comparison.js
+++ b/src/main/player/content-comparison.js
@@ -3,6 +3,7 @@ const platform = require("rise-common-electron").platform;
 const commonConfig = require("common-display-module");
 
 const contentComparisonFileName = ".content-comparison.json";
+const defaultPresentationId = "2b95b77e-839c-4674-b020-e2198df49061";
 
 module.exports = {
   compareContentData(newData) {
@@ -10,9 +11,12 @@ module.exports = {
 
     const newPresDates = getPresDatesFromContent(newData);
 
-    const newSchedDate = {
+    const newSchedDate = newData.content.schedule ? {
       id: newData.content.schedule.id,
       changeDate: newData.content.schedule.changeDate
+    } : {
+      id: "no-schedule",
+      changeDate: "no-schedule"
     };
 
     return readContentDates()
@@ -38,10 +42,17 @@ module.exports = {
 function validateData(newData) {
   if (!newData) { return false; }
   if (!newData.content) { return false; }
-  if (!newData.content.schedule) { return false; }
   if (!newData.content.presentations) { return false; }
+  if (!newData.content.schedule &&
+  !isDefaultContentJson(newData.content.presentations)) { return false; }
 
   return true;
+}
+
+function isDefaultContentJson(presentations) {
+  return Array.isArray(presentations) &&
+  presentations.length === 1 &&
+  presentations[0].id === defaultPresentationId;
 }
 
 function getPresDatesFromContent({ content }) {

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -136,6 +136,7 @@ module.exports = {
     viewerWindow = new BrowserWindow(Object.assign({
       "center": !customResolution,
       "fullscreen": !customResolution,
+      "alwaysOnTop": true,
       "frame": false,
       "icon": path.join(app.getAppPath(), "installer", "ui", "img", "icon.png"),
       "webPreferences": {

--- a/src/test/unit/content-comparison.js
+++ b/src/test/unit/content-comparison.js
@@ -251,6 +251,19 @@ describe('Content Comparison', () => {
       .catch(() => assert.ok(true));
     });
 
+    it('should pass without a schedule if default content.json', () => {
+      const data = {
+        content: {
+          presentations: [
+            {
+              id: "2b95b77e-839c-4674-b020-e2198df49061"
+            }
+          ]
+        }
+      };
+
+      return contentComparison.compareContentData(data);
+    });
     it('passing', () => {
       const data = {
         content: {


### PR DESCRIPTION
Content comparison should expect content with no schedule object for
cases when the display is using the default schedule.