### PR TITLE
Remove restriction to RiseStorage URLS for no-viewer

### DIFF
--- a/src/main/scheduling/schedule-parser.js
+++ b/src/main/scheduling/schedule-parser.js
@@ -21,16 +21,13 @@ const DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
 
 module.exports = {
   scheduledToPlay,
-  hasOnlyRiseStorageURLItems(data = scheduleContent) {
+  hasOnlyURLItems(data = scheduleContent) {
     if (!module.exports.validateContent()) {return false;}
-
-    const expectedURLStart = "https://storage.googleapis.com/risemedialibrary";
 
     return data.content.schedule.items.every(item=>{
       if (item.type !== "url") {return false;}
       if (!item.objectReference) {return false;}
       if (typeof item.objectReference !== "string") {return false;}
-      if (!item.objectReference.startsWith(expectedURLStart)) {return false;}
 
       return true;
     });

--- a/src/main/viewer/content-loader.js
+++ b/src/main/viewer/content-loader.js
@@ -91,7 +91,7 @@ module.exports = {
     uptime.setSchedule(content);
   },
   sendContentToViewer(content) {
-    if (scheduleParser.hasOnlyRiseStorageURLItems()) {
+    if (scheduleParser.hasOnlyURLItems()) {
       return;
     }
     expectedReady = countWidgets(content);

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -240,7 +240,7 @@ function isViewerLoaded() {
 }
 
 function loadContent(content) {
-  if (scheduleParser.hasOnlyRiseStorageURLItems()) {
+  if (scheduleParser.hasOnlyURLItems()) {
     logClientInfo();
     dataHandlerRegistered = false;
     viewerWindowBindings.sendToRenderer("begin-substituting-viewer-pings-to-watchdog");

--- a/src/test/unit/viewer/controller.js
+++ b/src/test/unit/viewer/controller.js
@@ -182,7 +182,7 @@ describe("viewerController", ()=>{
 
     it("creates a no-viewer window", ()=>{
       simple.mock(onlineDetection, "isOnline").returnWith(true);
-      simple.mock(scheduleParser, "hasOnlyRiseStorageURLItems").returnWith(true);
+      simple.mock(scheduleParser, "hasOnlyURLItems").returnWith(true);
       simple.mock(noViewerSchedulePlayer, "start").returnWith(true);
 
       simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({
@@ -387,7 +387,7 @@ describe("viewerController", ()=>{
       simple.mock(viewerController, "launch").resolveWith(mocks.viewerWindow);
       simple.mock(viewerContentLoader, "sendContentToViewer").returnWith();
       simple.mock(scheduleParser, "setContent").resolveWith({});
-      simple.mock(scheduleParser, "hasOnlyRiseStorageURLItems").returnWith(false);
+      simple.mock(scheduleParser, "hasOnlyURLItems").returnWith(false);
 
       return viewerController.reload().then(()=>{
         assert.equal(gcs.getFileContents.lastCall.args[0], "test/path");


### PR DESCRIPTION
Initially **no-viewer** mode was limited to Rise Storage urls based on a
specific target url. We need to enable more urls for widget staging as
well as other Rise Storage origins like commondatastorage.googleapis.

Rather than a specific whitelist, we now enable no-viewer for *any* urls.
There's no reason to load urls in Viewer.