### PR TITLE
Staging/viewer url override fix

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
     "done": false,
     "chrome": false,
     "setTimeout": false,
+    "setImmediate": false,
     "setInterval": false,
     "clearInterval": false,
     "clearTimeout": false,

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -111,7 +111,7 @@ function logClientInfo(data) {
 
 function createViewerUrl() {
   const displaySettings = commonConfig.getDisplaySettingsSync();
-  const overrideUrl = displaySettings.viewerurl;
+  const overrideUrl = displaySettings.debugviewerurl;
   const id = displaySettings.displayid || "";
 
   let url = overrideUrl || VIEWER_URL;

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -62,8 +62,6 @@ function registerEvents(window) {
       if (dataHandlerRegistered && typeof dataHandlerRegistered === "function") {
         dataHandlerRegistered();
       }
-
-      dataHandlerRegistered = true;
     } else if (data.message === "widget-ready") {
       viewerContentLoader.incrementReady(data.widgetUrl);
     } else if (data.message === "widget-log") {
@@ -81,7 +79,6 @@ function registerEvents(window) {
         log.all("switching from offline to online viewer");
 
         window.destroy();
-        dataHandlerRegistered = false;
         globalShortcut.unregister("CommandOrControl+Shift+.");
         module.exports.reload();
 
@@ -188,6 +185,7 @@ function createViewerWindow(initialPage = "about:blank") {
 }
 
 function setCertificateHandling(url = VIEWER_URL) {
+  if (!viewerWindow) {return;}
   viewerWindow.webContents.session.setCertificateVerifyProc((request, callback) => {
     const {hostname, certificate, verificationResult, errorCode} = request;
     if (hostname === "localhost" && certificate.issuer.organizations[0] === "Rise Vision") {
@@ -209,13 +207,13 @@ function loadViewerUrl() {
     .then(url => loadUrl(url))
     .then(()=>{
       return new Promise((res)=>{
-        if (dataHandlerRegistered) {return res();}
         dataHandlerRegistered = res;
       });
     });
 }
 
 function loadUrl(url) {
+  if (!viewerWindow) {return;}
   log.external("loading url", url);
 
   setCertificateHandling(url);
@@ -246,7 +244,6 @@ function isViewerLoaded() {
 function loadContent(content) {
   if (scheduleParser.hasOnlyNoViewerURLItems()) {
     logClientInfo();
-    dataHandlerRegistered = false;
     viewerWindowBindings.sendToRenderer("begin-substituting-viewer-pings-to-watchdog");
     return Promise.resolve(noViewerSchedulePlayer.start());
   }

--- a/src/test/unit/main-controller.js
+++ b/src/test/unit/main-controller.js
@@ -51,7 +51,7 @@ mocks.globalShortcut = {
 };
 
 mocks.BrowserWindow = function() {
-  return {loadURL(){}};
+  return {on(){}, loadURL(){}};
 };
 
 mocks.protocol = {

--- a/src/test/unit/viewer/controller.js
+++ b/src/test/unit/viewer/controller.js
@@ -153,25 +153,25 @@ describe("viewerController", ()=>{
     it("uses the url from the config file", ()=>{
       simple.mock(onlineDetection, "isOnline").returnWith(true);
 
-      let viewerurl = "http://override-dot-rvaviewer-test.appspot.com/Viewer.html?";
-      simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({viewerurl});
+      let debugviewerurl = "http://override-dot-rvaviewer-test.appspot.com/Viewer.html?";
+      simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({debugviewerurl});
 
       return launchViewer()
       .then(()=>{
         console.log(mocks.viewerWindow.loadURL.calls);
-        assert(mocks.viewerWindow.loadURL.calls[1].args[0].startsWith(viewerurl));
+        assert(mocks.viewerWindow.loadURL.calls[1].args[0].startsWith(debugviewerurl));
       });
     });
 
     it("uses the url from the config file correctly when it doesn't end with a question mark", ()=>{
       simple.mock(onlineDetection, "isOnline").returnWith(true);
 
-      let viewerurl = "http://override-dot-rvaviewer-test.appspot.com/Viewer.html";
-      simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({viewerurl});
+      let debugviewerurl = "http://override-dot-rvaviewer-test.appspot.com/Viewer.html";
+      simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({debugviewerurl});
 
       return launchViewer()
       .then(()=>{
-        assert(mocks.viewerWindow.loadURL.calls[1].args[0].startsWith(viewerurl + "?"));
+        assert(mocks.viewerWindow.loadURL.calls[1].args[0].startsWith(debugviewerurl + "?"));
       });
     });
 


### PR DESCRIPTION
@andrecardoso The first commit corrects the timing problem that was resulting in the infinite spinner. I wanted to make sure the underlying issue (see commit message) was known before ignoring the override url. I left that correction in even though the override is removed in the last commit, which would also fix the problem.