### PR TITLE
Add endpoint checks during uptime failures

### DIFF
--- a/src/main/uptime/investigation.js
+++ b/src/main/uptime/investigation.js
@@ -1,0 +1,25 @@
+const network = require("rise-common-electron").network;
+const timeout = 3000;
+
+const siteList = [
+  "https://services.risevision.com/healthz",
+  "https://viewer.risevision.com",
+  "https://storage-dot-rvaserver2.appspot.com",
+  "https://store.risevision.com",
+  "https://aws.amazon.com/s3/",
+  "https://storage.googleapis.com/install-versions.risevision.com/display-modules-manifest.json",
+  "https://www.googleapis.com/storage/v1/b/install-versions.risevision.com/o/installer-win-64.exe?fields=kind"
+];
+
+module.exports = {
+  reportConnectivity() {
+    siteList.forEach(site=>{
+      return network.httpFetch(site, {timeout})
+      .then(res=>{
+        log.external("downtime network check", `${res.statusCode} - ${site}`);
+      }).catch((error)=>{
+        log.external("downtime network error", `${error} - ${site}`);
+      });
+    });
+  }
+};

--- a/src/main/uptime/uptime.js
+++ b/src/main/uptime/uptime.js
@@ -1,4 +1,5 @@
 const messaging = require("common-display-module/messaging");
+const investigation = require("./investigation");
 const uptimeLogger = require("../loggers/uptime-logger");
 const scheduleParser = require("../scheduling/schedule-parser");
 const pingTimeout = 3000;
@@ -36,6 +37,7 @@ function calculate() {
     const connectedToMS = msResult === 'connected';
     log.file('uptime', JSON.stringify({shouldBePlaying, connectedToMS, rendererResult}));
 
+    if (!connectedToMS) {investigation.reportConnectivity();}
     uptimeLogger.log(connectedToMS, rendererResult, shouldBePlaying);
   })
   .catch((e)=>{


### PR DESCRIPTION
![net-check](https://user-images.githubusercontent.com/1511535/53987771-f26b7200-40ef-11e9-9bfe-455b45662b6e.png)

Opted to check on every uptime network failure so we don't miss out on useful data.