### PR TITLE
Update aws url

### DIFF
--- a/src/main/uptime/investigation.js
+++ b/src/main/uptime/investigation.js
@@ -6,7 +6,8 @@ const siteList = [
   "https://viewer.risevision.com",
   "https://storage-dot-rvaserver2.appspot.com",
   "https://store.risevision.com",
-  "https://aws.amazon.com/s3/",
+  "http://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html",
+  "https://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html",
   "https://storage.googleapis.com/install-versions.risevision.com/display-modules-manifest.json",
   "https://www.googleapis.com/storage/v1/b/install-versions.risevision.com/o/installer-win-64.exe?fields=kind"
 ];


### PR DESCRIPTION
This url is more inline with [documentation](https://help.risevision.com/hc/en-us/articles/115002459246-Rise-Player-network-requirements) while returning a smaller payload than the root url, and also being more to the point.