### PR TITLE
register did-fail-load just once

### DIFF
--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -47,6 +47,10 @@ function registerEvents(window) {
 
   webContents.on('destroyed', ()=> log.all('viewer webContents destroyed'));
 
+  webContents.on("did-fail-load", (evt, errorCode, errorDescription, validatedURL, isMainFrame)=>{
+    log.external("error loading url", JSON.stringify({url: validatedURL, errorCode, errorDescription, isMainFrame}));
+  });
+
   globalShortcut.register("CommandOrControl+Shift+.", ()=>{
     if (window && window.isFocused()) {
       webContents.toggleDevTools();
@@ -175,10 +179,6 @@ function createViewerWindow(initialPage = "about:blank") {
       if (!cb) {cb = authInfo;}
       cb(proxy.configuration().username, proxy.configuration().password);
     }
-  });
-
-  viewerWindow.webContents.on("did-fail-load", (evt, errorCode, errorDescription, validatedURL, isMainFrame)=>{
-    log.external("error loading url", JSON.stringify({url: validatedURL, errorCode, errorDescription, isMainFrame}));
   });
 
   return viewerWindow;

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -177,6 +177,10 @@ function createViewerWindow(initialPage = "about:blank") {
     }
   });
 
+  viewerWindow.webContents.on("did-fail-load", (evt, errorCode, errorDescription, validatedURL, isMainFrame)=>{
+    log.external("error loading url", JSON.stringify({url: validatedURL, errorCode, errorDescription, isMainFrame}));
+  });
+
   return viewerWindow;
 }
 
@@ -234,11 +238,7 @@ function loadUrl(url) {
     log.external("url load timeout", url);
   }, 2.5 * 60 * 1000);
 
-  viewerWindow.webContents.on("did-fail-load", (evt, errorCode, errorDescription, validatedURL, isMainFrame)=>{
-    log.external("error loading url", JSON.stringify({url: validatedURL, errorCode, errorDescription, isMainFrame}));
-  });
-
-  viewerWindow.webContents.on("did-finish-load", ()=>clearTimeout(viewerTimeout));
+  viewerWindow.webContents.once("did-finish-load", ()=>clearTimeout(viewerTimeout));
 }
 
 function isViewerLoaded() {
@@ -332,5 +332,6 @@ module.exports = {
     let htmlPath = path.join(app.getAppPath(), "/dupe-id.html?" + commonConfig.getDisplaySettingsSync().displayid);
     viewerWindow.loadURL("file://" + htmlPath);
   },
-  createViewerWindow
+  createViewerWindow,
+  loadUrl
 };

--- a/src/test/unit/viewer/controller.js
+++ b/src/test/unit/viewer/controller.js
@@ -19,6 +19,7 @@ mocks.app = {
 
 mocks.webContents = {
   on: simple.spy((evt, fn)=>{if(evt === "did-finish-load"){fn();}}),
+  once: simple.stub(),
   isLoading: simple.stub().returnWith(false),
   send: simple.stub(),
   session: {setProxy: simple.stub(), setCertificateVerifyProc: simple.stub()},
@@ -160,6 +161,27 @@ describe("viewerController", ()=>{
       .then(()=>{
         console.log(mocks.viewerWindow.loadURL.calls);
         assert(mocks.viewerWindow.loadURL.calls[1].args[0].startsWith(debugviewerurl));
+      });
+    });
+
+    it("should not register extra handlers after loading URLs", ()=>{
+      simple.mock(onlineDetection, "isOnline").returnWith(true);
+
+      let debugviewerurl = "http://override-dot-rvaviewer-test.appspot.com/Viewer.html?";
+      simple.mock(commonConfig, "getDisplaySettingsSync").returnWith({debugviewerurl});
+
+      return launchViewer()
+      .then(()=>{
+        // 1: 'crashed', 2: 'destroyed', 3: 'login', 4: 'did-fail-load'
+        assert.equal(mocks.viewerWindow.webContents.on.calls.length, 4);
+        assert.equal(mocks.viewerWindow.webContents.once.calls.length, 1);
+
+        viewerController.loadUrl("blank:");
+
+        // no extra calls should happen here
+        assert.equal(mocks.viewerWindow.webContents.on.calls.length, 4);
+        // an extra once call should happen here
+        assert.equal(mocks.viewerWindow.webContents.once.calls.length, 2);
       });
     });
 

--- a/src/test/unit/viewer/controller.js
+++ b/src/test/unit/viewer/controller.js
@@ -172,7 +172,7 @@ describe("viewerController", ()=>{
 
       return launchViewer()
       .then(()=>{
-        // 1: 'crashed', 2: 'destroyed', 3: 'login', 4: 'did-fail-load'
+        // 1: 'crashed', 2: 'destroyed', 3: 'did-fail-load', 4: 'login'
         assert.equal(mocks.viewerWindow.webContents.on.calls.length, 4);
         assert.equal(mocks.viewerWindow.webContents.once.calls.length, 1);
 


### PR DESCRIPTION
## Description
Avoid multiple registration of error events in viewer window.

## Motivation and Context
In some cases loadUrl seems to be called more than once, resulting in multiple registration of the error event handler for 'did-fail-load'. This seems to be causing heavy reporting of 'error loading url' for some displays, see for example:

```
SELECT count(*) AS count, display_id  
FROM [client-side-events:Installer_Events.events20190830]
WHERE event = 'error loading url'
GROUP BY display_id
ORDER BY count DESC
LIMIT 20
```

In some cases, the error gets reported every few milliseconds, which in turn may cause networking issues that may result in other issues for the display. In this particular case, we saw this was very high on some of the displays affected by 'data file read error' as reported here:
https://github.com/Rise-Vision/common-template/issues/83
and with data analyzed here:
https://docs.google.com/document/d/1Qpge6eicKjw7EPQ3Qs0XE012MRmfJqMQrKTCdz8WmNc/edit#
https://trello.com/c/POcke0Rw/7216-issue-83-watch-module-is-logging-data-file-read-error-for-certain-displays-investigation-2

## How Has This Been Tested?
I staged a version of this changes here:
https://storage.googleapis.com/install-versions.risevision.com/staging/player-electron/2019.08.30.17.53/player-electron.sh

and tested locally with a schedule with both valid and some invalid URLs to ensure the error was still reported correctly.

Automated unit tests were also added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - Manual and updated tests were added.
    - Release plan will follow current player release process. First it will be released and tested on beta, and then will be gradually released to stable, and will rollback to previous version if there are problems.
    - I'll notify support once this is fix released.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation.
