### PR TITLE
Fix rchttps scheme handler

### DIFF
--- a/src/main/player/main-controller.js
+++ b/src/main/player/main-controller.js
@@ -19,7 +19,8 @@ function schemeHandler(request, callback) {
   let rcUrl = request.url.replace('rchttp', 'http');
   const regex = /http[s]?:\/\/localhost[\/|?]/g;
   if (regex.test(rcUrl)) {
-    rcUrl = rcUrl.replace('localhost', 'localhost:9494');
+    const port = rcUrl.indexOf('https') === 0 ? '9495' : '9494';
+    rcUrl = rcUrl.replace('localhost', `localhost:${port}`);
   }
 
   const redirect = {

--- a/src/test/unit/main-controller.js
+++ b/src/test/unit/main-controller.js
@@ -295,7 +295,7 @@ describe("mainController", ()=>{
       }, callback);
 
       assert.deepEqual(callback.lastCall.args[0], {
-        url: "https://localhost:9494?file=https://storage.googleapis.com/risemedialibrary-abc123/test.webm",
+        url: "https://localhost:9495?file=https://storage.googleapis.com/risemedialibrary-abc123/test.webm",
         method: "GET"
       });
     });
@@ -310,7 +310,7 @@ describe("mainController", ()=>{
       }, callback);
 
       assert.deepEqual(callback.lastCall.args[0], {
-        url: "https://localhost:9494/displays",
+        url: "https://localhost:9495/displays",
         method: "GET"
       });
     });
@@ -320,12 +320,12 @@ describe("mainController", ()=>{
         callback = simple.stub();
 
       handlerFn({
-        url: "rchttps://localhost:9494/displays",
+        url: "rchttps://localhost:9495/displays",
         method: "GET",
       }, callback);
 
       assert.deepEqual(callback.lastCall.args[0], {
-        url: "https://localhost:9494/displays",
+        url: "https://localhost:9495/displays",
         method: "GET"
       });
     });


### PR DESCRIPTION
## Description
Include port 9495 in the redirect URL if custom scheme is rchttps

## Motivation and Context
Rise Cache runs https server over port 9495. The scheme URL handler is incorrectly sending rchttps requests to port 9494

## How Has This Been Tested?
Tested manually on my Linux box

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
