### PR TITLE
Increase timeout on GCS polling test

### DIFF
--- a/src/test/integration/gcs-polling.js
+++ b/src/test/integration/gcs-polling.js
@@ -7,7 +7,7 @@ const platform = require("rise-common-electron").platform;
 const commonConfig = require("common-display-module");
 
 describe("GCS Polling", function() {
-  this.timeout(8000);
+  this.timeout(10000);
 
   afterEach(()=>{
     simple.restore();


### PR DESCRIPTION
## Description
Increases the timeout to fix GCS polling integration tests

## Motivation and Context
GCS polling integration tests started failing without any related change

## How Has This Been Tested?
Tested locally and on CI

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

