### PR TITLE
Clear timeout in playItems() to avoid unnecessary playItems() calls.

### DIFF
--- a/src/main/scheduling/schedule-player.js
+++ b/src/main/scheduling/schedule-player.js
@@ -68,6 +68,8 @@ function playCurrentlyPlayableItems(now) {
 }
 
 function playItems() {
+  clearTimeout(timers.itemDuration);
+
   if (playingItem && playingItem.playUntilDone && !playUntilDoneTracker.isDone()) {
     timers.itemDuration = setTimeout(playItems, 1000);
     return;


### PR DESCRIPTION
## Description
Clear timeout in `playItems()` to avoid unnecessary `playItems()` calls.

## Motivation and Context
Every time `"content-update"` message is received and `noViewerSchedulePlayer.start()` is called, it initiates a new timer loop for the `playItems()` method. 
Example: when content is loaded first time time, the `playItems()` is called once a second, then on the next `"content-update"` it is called twice a second and so on.

## How Has This Been Tested?
It was tested manually using logs.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
