### PR TITLE
Fix for issue 824 - handle exception when starting rise cache

### DIFF
--- a/src/main/player/rise-cache-watchdog.js
+++ b/src/main/player/rise-cache-watchdog.js
@@ -7,9 +7,10 @@ const inspect = require("util").inspect;
 const riseCacheLogger = require("../loggers/rise-cache-logger");
 
 let cache = null;
+let timer = null;
 
 function scheduleCacheCheck() {
-  setInterval(()=>{
+  timer = setInterval(()=>{
     isCacheRunning()
       .catch((err)=>{
         log.external("restarting cache", inspect(err));
@@ -73,5 +74,8 @@ module.exports = {
   },
   startWatchdog() {
     scheduleCacheCheck();
+  },
+  stop() {
+    clearInterval(timer);
   }
 };

--- a/src/main/player/rise-cache-watchdog.js
+++ b/src/main/player/rise-cache-watchdog.js
@@ -43,6 +43,10 @@ function startCache() {
     cache.on("message", (data) => {
       riseCacheLogger.log(data);
     });
+
+    cache.on("error", (err) => {
+      log.error(`error when killing rise cache v2: ${ inspect(err) }`, "killing rise cache v2");
+    });
   }
   catch (err) {
     cache = null;
@@ -62,7 +66,7 @@ module.exports = {
     startCache();
   },
   quitCache() {
-    if (cache) { 
+    if (cache) {
       log.external("killing rise cache");
       cache.send("quit");
     }


### PR DESCRIPTION
## Description
Add error handling on Rise Cache watchdog to avoid crashing when there is an error when sending the "quit" message to Rise Cache process. 

## Motivation and Context
This should fix https://github.com/Rise-Vision/rise-launcher-electron/issues/824

## How Has This Been Tested?
Tested manually on Pi

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
