### PR TITLE
Use test store server when player configured to stage

### DIFF
--- a/src/main/player/offline-subscription-check.js
+++ b/src/main/player/offline-subscription-check.js
@@ -1,14 +1,17 @@
 const {network} = require("rise-common-electron");
 const onlineDetection = require("../player/online-detection.js");
 const authHost = "store-dot-rvaserver2.appspot.com";
+const authHostStage = "store-dot-rvacore-test.appspot.com";
 const commonConfig = require("common-display-module");
 const productCode = "c4b368be86245bf9501baaa6e0b00df9719869fd";
-const authorizationUrl = `https://${authHost}/v1/widget/auth?id=DID&pc=${productCode}&startTrial=false`;
 const OFFLINE_SUBSCRIPTION_FILE = "../8f0bfd16129083c1ad67370c916be014";
 
 function remoteSubscriptionStatus() {
   const displayId = commonConfig.getDisplaySettingsSync().displayid;
   if (!displayId) {return false;}
+
+  const host = commonConfig.isStageEnvironment() ? authHostStage : authHost;
+  const authorizationUrl = `https://${host}/v1/widget/auth?id=DID&pc=${productCode}&startTrial=false`;
 
   return network.httpFetch(authorizationUrl.replace("DID", displayId))
   .then(resp=>resp.json())

--- a/src/test/unit/offline-subscription-check.js
+++ b/src/test/unit/offline-subscription-check.js
@@ -28,6 +28,17 @@ describe("Offline Subscription Check", ()=>{
       assert(network.httpFetch.called);
       assert(jsonStub.called);
       assert(network.httpFetch.firstCall.args[0].includes("testid"));
+      assert(network.httpFetch.firstCall.args[0].includes("store-dot-rvaserver2.appspot.com"));
+    });
+  });
+
+  it("uses the stage URL is player is configured to stage", ()=>{
+    simple.mock(commonConfig, "isStageEnvironment").resolveWith(true);
+
+    return checker.isSubscribed()
+    .then(()=>{
+      assert(network.httpFetch.called);
+      assert(network.httpFetch.firstCall.args[0].includes("store-dot-rvacore-test.appspot.com"));
     });
   });
 


### PR DESCRIPTION
## Description
Use test store server to log client info when player is configured to stage

## Motivation and Context
Designers need to test staging templates

## How Has This Been Tested?
Tested manually with staging package. Added unit test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
