### PR TITLE
Fix IPC error handler on player watchdog

### DIFF
--- a/src/main/player/watchdog.js
+++ b/src/main/player/watchdog.js
@@ -1,5 +1,6 @@
-const childProcess = require("child_process"),
-path = require("path");
+const childProcess = require("child_process");
+const inspect = require("util").inspect;
+const path = require("path");
 
 let watchdog;
 let watchdogPingInterval;
@@ -19,9 +20,7 @@ module.exports = {
   },
 
   send(message) {
-    try {
-      watchdog.send(message);
-    } catch (err) { }
+    watchdog.send(message);
   },
 
   // Set up mainProcess-watchdog communication
@@ -45,6 +44,10 @@ module.exports = {
         clearTimeout(watchdogResponseTimeout);
         watchdogResponseTimeout = null;
       }
+    });
+
+    watchdog.on("error", (err) => {
+      log.error(`error on watchdog process communication: ${ inspect(err) }`, "ping player watchdog");
     });
   },
 

--- a/src/main/watchdog/index.js
+++ b/src/main/watchdog/index.js
@@ -34,7 +34,7 @@ function restartPlatform(component) {
          "cmd.exe" :
           path.join(scriptDir, "start.sh");
 
-  const args = isWindows() ? 
+  const args = isWindows() ?
          ["/c", path.join(scriptDir, "background.jse"), "start.bat"].concat(commonArgs) :
           commonArgs;
 
@@ -65,3 +65,5 @@ process.on("message", (contents)=>{
     });
   }
 });
+
+process.on("SIGPIPE", () => log.external("player watchdog received SIGPIPE"));


### PR DESCRIPTION
## Description
- Fix IPC error handler on player watchdog
- Add SIGPIPE handler to avoid crashing watchdog

## Motivation and Context
Fix error handling on IPC on player watchdog process. Avoid player crashes when there is an IPC error.

## How Has This Been Tested?
Tested manually with the staging package

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
