### PR TITLE
Update rise-cache dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4220,8 +4220,8 @@
       }
     },
     "rise-cache-v2": {
-      "version": "git://github.com/Rise-Vision/rise-cache-v2.git#8ed2757e71df6707c0c6e25311672e925ee6fbc0",
-      "from": "git://github.com/Rise-Vision/rise-cache-v2.git#v1.7.10",
+      "version": "git://github.com/Rise-Vision/rise-cache-v2.git#756c6c339342e877642296972e2dbbc2ceab2108",
+      "from": "git://github.com/Rise-Vision/rise-cache-v2.git#v1.8.0",
       "requires": {
         "body-parser": "^1.19.0",
         "cors": "~2.7.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "electron-proxy-agent": "git://github.com/Rise-Vision/node-electron-proxy-agent.git#v1.0.3",
     "moment-timezone": "^0.5.17",
     "primus": "^7.3.3",
-    "rise-cache-v2": "git://github.com/Rise-Vision/rise-cache-v2.git#v1.7.10",
+    "rise-cache-v2": "git://github.com/Rise-Vision/rise-cache-v2.git#v1.8.0",
     "rise-common-electron": "git://github.com/Rise-Vision/rise-common-electron.git#v2.2.10",
     "ws": "^7.1.2"
   },


### PR DESCRIPTION
## Description

The latest version of Rise Cache stopped working for external URLs configured on Image Widget. This PR changes it to a RC commit to quick fix the problem.

## Motivation and Context

Fix to https://github.com/Rise-Vision/rise-launcher-electron/issues/831 

## How Has This Been Tested?
Validated manually with the staged version.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
