### PR TITLE
Restart playing item on content-update when in no-viewer mode

### DIFF
--- a/src/main/scheduling/schedule-player.js
+++ b/src/main/scheduling/schedule-player.js
@@ -17,6 +17,7 @@ module.exports = {
   start() {
     log.external("no-viewer mode");
     clearTimeout(timers.scheduleCheck);
+    playingItem = null;
 
     if (!scheduleParser.validateContent()) {
       logWithScheduleData("invalid schedule data");

--- a/src/test/unit/scheduling/schedule-player.js
+++ b/src/test/unit/scheduling/schedule-player.js
@@ -348,6 +348,34 @@ describe("Schedule Player", ()=>{
 
       assert(played.includes("test-url-1") && !played.includes("test-url-2"));
     });
+
+    it("restarts playing item if start is called and item is still valid", ()=>{
+      setTimeout.reset();
+      simple.mock(global, "setTimeout").returnWith();
+
+      const testData = {content: {
+        schedule: {
+          name: "test schedule",
+          timeDefined: false,
+          items: [
+            {
+              name: "test item 1",
+              timeDefined: false,
+              objectReference: "test-url-1",
+              duration: 10
+            }
+          ]
+        }
+      }};
+      scheduleParser.setContent(testData);
+      schedulePlayer.start();
+      played.lenght = 0;
+      scheduleParser.setContent(testData);
+      schedulePlayer.start();
+
+      assert.equal(played.includes("test-url-1"), true);
+    });
+
   });
 
   describe("Scenarios", ()=>{


### PR DESCRIPTION
## Description
Change scheduling code to restart the current playing item on `content-update` event

## Motivation and Context
Why is this change required? What problem does it solve?

Fix issue where template is not reloaded when single item schedule is saved: https://github.com/Rise-Vision/rise-slides/issues/32

## How Has This Been Tested?
Tested on staging using this schedule: https://apps-stage-0.risevision.com/schedules/details/47aadac8-cde4-4ac4-a5c4-67d7fb7a5d5f?cid=b258739a-527b-438c-b6ec-01057cecdfa2

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
