### PR TITLE
Fix quit on windows

### DIFF
--- a/src/main/player/main-controller.js
+++ b/src/main/player/main-controller.js
@@ -109,7 +109,14 @@ module.exports = {
     const possibleKeys = ["Q", "K", "F4"];
     possibleKeys.some((key)=>{
       const accelerator = `CommandOrControl+Shift+${key}`;
-      globalShortcut.register(accelerator, module.exports.quit);
+      let quitCalled = false;
+      globalShortcut.register(accelerator, () => {
+        if (quitCalled) {
+          return;
+        }
+        quitCalled = true;
+        module.exports.quit();
+      });
       return globalShortcut.isRegistered(accelerator);
     }) || log.external("error", "could not register quit hotkey");
 

--- a/src/main/player/main-controller.js
+++ b/src/main/player/main-controller.js
@@ -112,6 +112,8 @@ module.exports = {
       globalShortcut.register(accelerator, module.exports.quit);
       return globalShortcut.isRegistered(accelerator);
     }) || log.external("error", "could not register quit hotkey");
+
+    app.on('will-quit', () => globalShortcut.unregisterAll());
   },
 
   mainWindow

--- a/src/test/unit/main-controller.js
+++ b/src/test/unit/main-controller.js
@@ -135,6 +135,14 @@ describe("mainController", ()=>{
     });
   });
 
+  describe("bindQuitAccelerator", ()=>{
+    it("registers quit shortcuts", ()=>{
+      mainController.bindQuitAccelerator();
+
+      assert.equal(mocks.globalShortcut.register.called, true);
+    });
+  });
+
   describe("ready", ()=>{
     beforeEach(()=>{
       simple.mock(config, "setSystemInfo").returnWith();


### PR DESCRIPTION
## Description
Avoid calling `module.exports.quit` repeatedly.

## Motivation and Context
Player is causing multiple explorer windows to appear when quit shortcut is typed multiple times https://github.com/Rise-Vision/rise-launcher-electron/issues/840. 

## How Has This Been Tested?
Tested on uptime machines

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
