### PR TITLE
Allow more than one gcs content fetch per hour

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ rm -rf build-temp/viewer/localviewer/components
 mv build-temp/widgets build-temp/viewer/localviewer
 mv build-temp/components build-temp/viewer/localviewer
 rm -rf node_modules
-sudo npm install -g asar
+sudo npm install -g asar@v2.1.0
 npm install --production
 cp -r node_modules build-temp
 rm -rf build

--- a/src/test/integration/gcs.js
+++ b/src/test/integration/gcs.js
@@ -72,6 +72,7 @@ describe("GCS", function() {
       [remotePath]: {
         "generation": "-1",
         "lastFetch": (new Date()).getTime(),
+        "lastFetchCount": 9,
         "content": {
           "test": fakeCommand
         }

--- a/src/test/unit/gcs.js
+++ b/src/test/unit/gcs.js
@@ -1,0 +1,75 @@
+const gcs = require("../../main/player/gcs.js");
+const network= require("rise-common-electron").network;
+const commonConfig = require("common-display-module");
+const assert = require("assert");
+const simpleMock = require("simple-mock");
+const platform = require("rise-common-electron").platform;
+const mock = simpleMock.mock;
+const THROTTLED_MESSAGE = "gcs check throttled";
+
+describe("GCS", ()=>{
+  beforeEach(()=>{
+    mock(log, "file").returnWith();
+    mock(log, "external").callFn((...rest)=>console.log(...rest));
+    mock(log, "debug").callFn((...rest)=>console.log(...rest));
+    mock(network, "httpFetch").resolveWith({statusCode: 304});
+  });
+
+  afterEach(()=>{
+    simpleMock.restore();
+  });
+
+  it("throttles when hitting limit for the hour", ()=>{
+    const testPath = "/my-path";
+    const testData = {
+      [testPath]: {
+        lastFetch: Date.now(),
+        lastFetchCount: 9,
+        content: "test-content"
+      }
+    };
+
+    mock(commonConfig, "fileExists").returnWith(true);
+    mock(platform, "readTextFile").returnWith(Promise.resolve(JSON.stringify(testData)));
+
+    return gcs.getFileContents(testPath)
+    .then(result=>assert.equal(result,testData[testPath].content))
+    .then(()=>assert.equal(network.httpFetch.callCount, 0))
+    .then(()=>assert(log.external.calls.some(call=>call.args[0] === THROTTLED_MESSAGE)));
+  });
+
+  it("doesn't throttle when no data is present for the path", ()=>{
+    const testPath = "/my-path";
+    const testData = {
+      ["someOtherTestPath"]: {
+        lastFetch: Date.now(),
+        lastFetchCount: 9,
+        content: "test-content"
+      }
+    };
+
+    mock(commonConfig, "fileExists").returnWith(true);
+    mock(platform, "readTextFile").returnWith(Promise.resolve(JSON.stringify(testData)));
+
+    return gcs.getFileContents(testPath)
+    .then(()=>assert.equal(network.httpFetch.callCount, 1))
+    .then(()=>assert(log.external.calls.every(call=>call.args[0] !== THROTTLED_MESSAGE)));
+  });
+
+  it("doesn't throttle when no last fetch count is present for the path", ()=>{
+    const testPath = "/my-path";
+    const testData = {
+      [testPath]: {
+        lastFetch: Date.now(),
+        content: "test-content"
+      }
+    };
+
+    mock(commonConfig, "fileExists").returnWith(true);
+    mock(platform, "readTextFile").returnWith(Promise.resolve(JSON.stringify(testData)));
+
+    return gcs.getFileContents(testPath)
+    .then(()=>assert.equal(network.httpFetch.callCount, 1))
+    .then(()=>assert(log.external.calls.every(call=>call.args[0] !== THROTTLED_MESSAGE)));
+  });
+});


### PR DESCRIPTION
## Description
Allow more than one gcs content fetch per hour at startup.
The count is maintained in the gcs cache file and incremented if the previous request was less than 60mins ago.

## Motivation and Context
Defect [858](https://github.com/Rise-Vision/rise-launcher-electron/issues/858)

## How Has This Been Tested?
Unit plus several manual tests on a display to confirm:

 - does not throttle if cache file is missing (new installation)
 - resets throttle count if a content update is made via MS
 - throttles if count is exceeded
 - unthrottles and resets count after an hour

## Release Plan:
- see [release process](https://docs.google.com/document/d/19tQ9aH9kqvGrjXAb4Jz3C1zcqo5cPl0eR7HLocsSCnw/edit#)