### PR TITLE
Update to load Viewer from widgets.risevision.com

### DIFF
--- a/src/main/uptime/investigation.js
+++ b/src/main/uptime/investigation.js
@@ -3,7 +3,7 @@ const timeout = 3000;
 
 const siteList = [
   "https://services.risevision.com/healthz",
-  "https://viewer.risevision.com",
+  "https://widgets.risevision.com/viewer/Viewer.html",
   "https://storage-dot-rvaserver2.appspot.com",
   "https://store.risevision.com",
   "http://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html",

--- a/src/main/viewer/controller.js
+++ b/src/main/viewer/controller.js
@@ -16,7 +16,7 @@ const scheduleParser = require("../scheduling/schedule-parser");
 const noViewerSchedulePlayer = require("../scheduling/schedule-player");
 const messaging = require("../player/messaging");
 
-const VIEWER_URL = "https://viewer.risevision.com/Viewer.html?";
+const VIEWER_URL = "https://widgets.risevision.com/viewer/Viewer.html?";
 
 let BrowserWindow;
 let app;


### PR DESCRIPTION
## Description
Load Viewer from `https://widgets.risevision.com/viewer/Viewer.html` 

## Motivation and Context
Origin consolidation

## How Has This Been Tested?
Staged version of player - `https://storage.googleapis.com/install-versions.risevision.com/staging/player-electron/2021.01.04.21.15/player-electron.exe` and extracted it to appropriate folder on my VB Win 10 x32 machine. 

Validated viewer correctly loaded from right location and validated content with this schedule https://apps.risevision.com/schedules/details/9be18cf4-b565-4870-a454-43dc7f43daab?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f which contains 2 random templates and a legacy presentation containing a few different widgets. 

**PENDING**
Test legacy presentation containing gadgets, which is dependent on fixing `makeRequest` when Viewer loaded from widgets.risevision.com. 

## Release Plan:
- Update and deploy Viewer to fix `makeRequest` when loaded from widgets.risevision.com
- Rollout player
  - 5%, 10%, 25%, 50%, 100%

#### Release Checklist Items Skipped?
none
